### PR TITLE
Removed target ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,6 @@ AllCops:
     - 'db/schema.rb'
     - 'vendor/**/*'
 
-  TargetRubyVersion: 2.2
-
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
   # option.


### PR DESCRIPTION
Given that we’ve gone live with this repo, for security reasons, we’re removing the data about the target ruby version from it. By default rubocop will take target ruby version directly from .ruby-version. Please see https://rubocop.readthedocs.io/en/latest/configuration/ for more information.

This should go together with https://github.com/simplybusiness/chopin/pull/5946.