### PR TITLE
Updating rubocop

### DIFF
--- a/simplycop.gemspec
+++ b/simplycop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.36.0"
+  spec.add_dependency "rubocop", ">= 0.47.1"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This PR is connected to https://github.com/simplybusiness/chopin/pull/6263

It is to keep our rubocop inline with Code Climates version.